### PR TITLE
fix typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run **revgen** anywhere inside your go workspace to call all the generators for 
 ```shell
 > revgen --force
 ```
-Run **revgen --force** to run all the genrators regardless of code updates. 
+Run **revgen --force** to run all the generators regardless of code updates. 
 ***
 ```shell
 > revgen update


### PR DESCRIPTION
I corrected `genrators` as `generators`